### PR TITLE
The Node.JS version in the search skills lab is not updated

### DIFF
--- a/Instructions/Exercises/02-search-skills.md
+++ b/Instructions/Exercises/02-search-skills.md
@@ -146,7 +146,7 @@ To implement the word count functionality as a custom skill, you'll create an Az
     - **Function App name**: *A unique name*
     - **Publish**: Code
     - **Runtime stack**: Node.js
-    - **Version**: 14 LTS
+    - **Version**: 18 LTS
     - **Region**: *The same region as your Azure AI Search resource*
 
 2. Wait for deployment to complete, and then go to the deployed Function App resource.


### PR DESCRIPTION
In the lab file instructions there is the 14LTS  Node.JS version that is not available. I change the version with 18LTS.