### PR TITLE
LAB02: Update the instructions related to Function App creation

### DIFF
--- a/Instructions/Exercises/02-search-skills.md
+++ b/Instructions/Exercises/02-search-skills.md
@@ -151,9 +151,7 @@ To implement the word count functionality as a custom skill, you'll create an Az
 
 2. Wait for deployment to complete, and then go to the deployed Function App resource.
 
-3. On the **Overview** page select **Create in Azure portal** option to create a new function with the following settings:
-    - **Setup a development environment**"
-        - **Development environment**: Develop in portal
+3. On the **Overview** page click on the button **Create function** in the **Create in Azure portal** column to create a new function with the following settings:
     - **Select a template**"
         - **Template**: HTTP Trigger
     - **Template details**:

--- a/Instructions/Exercises/02-search-skills.md
+++ b/Instructions/Exercises/02-search-skills.md
@@ -141,15 +141,16 @@ To implement the word count functionality as a custom skill, you'll create an Az
 > **Note**: In this exercise, you'll create a simple Node.JS function using the code editing capabilities in the Azure portal. In a production solution, you would typically use a development environment such as Visual Studio Code to create a function app in your preferred language (for example C#, Python, Node.JS, or Java) and publish it to Azure as part of a DevOps process.
 
 1. In the Azure Portal, on the **Home** page, create a new **Function App** resource with the following settings:
+    - **Hosting Plan**: Consumption
     - **Subscription**: *Your subscription*
     - **Resource Group**: *The same resource group as your Azure AI Search resource*
     - **Function App name**: *A unique name*
-    - **Publish**: Code
-    - **Runtime stack**: Node.js
+    - **Runtime stack**: 
     - **Version**: 18 LTS
     - **Region**: *The same region as your Azure AI Search resource*
 
 2. Wait for deployment to complete, and then go to the deployed Function App resource.
+
 3. On the **Overview** page select **Create in Azure portal** option to create a new function with the following settings:
     - **Setup a development environment**"
         - **Development environment**: Develop in portal

--- a/Instructions/Exercises/02-search-skills.md
+++ b/Instructions/Exercises/02-search-skills.md
@@ -145,7 +145,7 @@ To implement the word count functionality as a custom skill, you'll create an Az
     - **Subscription**: *Your subscription*
     - **Resource Group**: *The same resource group as your Azure AI Search resource*
     - **Function App name**: *A unique name*
-    - **Runtime stack**: 
+    - **Runtime stack**: Node.js
     - **Version**: 18 LTS
     - **Region**: *The same region as your Azure AI Search resource*
 


### PR DESCRIPTION
I propose these changes:

- When you create a new function app, you need to choose the hosting plan first. I added this step in the instructions
- When you create a function from the Overview option in the portal you click on the button in the Create from portal column and  chose template end details. I updated the instruction for this new UI