### PR TITLE
Fix typo in first exercise

### DIFF
--- a/Instructions/Exercises/01-azure-search.md
+++ b/Instructions/Exercises/01-azure-search.md
@@ -315,7 +315,7 @@ While you can use the portal to create and modify search solutions, it's often d
 
     All of the other metadata and content fields in the source document are implicitly mapped to fields of the same name in the index.
 
-3. Review the **ouputFieldMappings** section, which maps outputs from the skills in the skillset to index fields. Most of these reflect the choices you made in the user interface, but the following mapping has been added to map the **sentimentLabel** value extracted by your sentiment skill to the **sentiment** field you added to the index:
+3. Review the **outputFieldMappings** section, which maps outputs from the skills in the skillset to index fields. Most of these reflect the choices you made in the user interface, but the following mapping has been added to map the **sentimentLabel** value extracted by your sentiment skill to the **sentiment** field you added to the index:
 
     ```json
     {


### PR DESCRIPTION
This pull request includes a small change to the `Instructions/Exercises/01-azure-search.md` file. The change corrects a typo in the word "outputFieldMappings" to ensure consistency and accuracy in the documentation.

* [`Instructions/Exercises/01-azure-search.md`](diffhunk://#diff-f8d99089ab3386a8dbc96bd27e98981219fada6756b2b8a7e29674b4ced2ee4aL318-R318): Corrected the typo from "ouputFieldMappings" to "outputFieldMappings".

