### PR TITLE
Update for Entity Recognition v3: remove / rename deprecated outputs and parameters

### DIFF
--- a/Labfiles/02-search-skill/update-search/update-skillset.json
+++ b/Labfiles/02-search-skill/update-search/update-skillset.json
@@ -70,7 +70,6 @@
         ],
         "defaultLanguageCode": "en",
         "minimumPrecision": null,
-        "includeTypelessEntities": null,
         "inputs": [
           {
             "name": "text",
@@ -87,8 +86,8 @@
             "targetName": "locations"
           },
           {
-            "name": "entities",
-            "targetName": "entities"
+            "name": "namedEntities",
+            "targetName": "namedEntities"
           }
         ]
       },


### PR DESCRIPTION
Update JSON file to accommodate changes in Entity Recognition cognitive skill v3:

- rename deprecated 'entities' output to namedEntities
- remove 'includeTypelessEntities' parameter

V3 docs: https://learn.microsoft.com/en-us/azure/search/cognitive-search-skill-entity-recognition-v3
Discontinued v2 docs: https://learn.microsoft.com/en-us/azure/search/cognitive-search-skill-entity-recognition