### PR TITLE
Update update-skillset.json to align with the current version

### DIFF
--- a/Labfiles/02-search-skill/update-search/update-skillset.json
+++ b/Labfiles/02-search-skill/update-search/update-skillset.json
@@ -70,7 +70,6 @@
         ],
         "defaultLanguageCode": "en",
         "minimumPrecision": null,
-        "includeTypelessEntities": null,
         "inputs": [
           {
             "name": "text",
@@ -87,7 +86,7 @@
             "targetName": "locations"
           },
           {
-            "name": "entities",
+            "name": "namedEntities",
             "targetName": "entities"
           }
         ]


### PR DESCRIPTION
`includeTypelessEntities` is deprecated

for Entity Recognition cognitive skill (v3), the output name should be `namedEntities` and not `entities`