### PR TITLE
Fix: 07 lab readme

### DIFF
--- a/Instructions/Exercises/07-exercise-add-to-index-use-push-api.md
+++ b/Instructions/Exercises/07-exercise-add-to-index-use-push-api.md
@@ -16,7 +16,7 @@ In this exercise, you'll clone an existing C# solution and run it to work out th
 
 To save you time, select this Azure Resource Manager template to create resources you'll need later in the exercise:
 
-1. [Deploy resources to Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoftLearning%2Fmslearn-knowledge-mining%2Fmain%2FLabfiles%2F07-exercise-add-to-index-use-push-api%20lab-files%2Fazuredeploy.json) - select this link to create your Azure AI resources.
+1. [Deploy resources to Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoftLearning%2Fmslearn-knowledge-mining%2Fmain%2FLabfiles%2F07-exercise-add-to-index-use-push-api%2Fazuredeploy.json) - select this link to create your Azure AI resources.
     ![A screenshot of the options shown when deploying resources to Azure.](../media/07-media/deploy-azure-resources.png)
 1. In **Resource group**, select **Create new**, name it **cog-search-language-exe**.
 1. In **Region**, select a [supported region](/azure/ai-services/language-service/custom-text-classification/service-limits#regional-availability) that is close to you.

--- a/Instructions/Labs/07-exercise-add-to-index-use-push-api.md
+++ b/Instructions/Labs/07-exercise-add-to-index-use-push-api.md
@@ -16,7 +16,7 @@ In this exercise, you'll clone an existing C# solution and run it to work out th
 
 To save you time, select this Azure Resource Manager template to create resources you'll need later in the exercise:
 
-1. [Deploy resources to Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoftLearning%2Fmslearn-knowledge-mining%2Fmain%2FLabfiles%2F07-exercise-add-to-index-use-push-api%20lab-files%2Fazuredeploy.json) - select this link to create your Azure AI resources.
+1. [Deploy resources to Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoftLearning%2Fmslearn-knowledge-mining%2Fmain%2FLabfiles%2F07-exercise-add-to-index-use-push-api%2Fazuredeploy.json) - select this link to create your Azure AI resources.
     ![A screenshot of the options shown when deploying resources to Azure.](../media/07-media/deploy-azure-resources.png)
 1. In **Resource group**, select **Create new**, name it **cog-search-language-exe**.
 1. In **Region**, select a [supported region](/azure/ai-services/language-service/custom-text-classification/service-limits#regional-availability) that is close to you.


### PR DESCRIPTION
Currently template url in lab 7 is incorrect. It loads this:
<img width="1121" height="191" alt="image" src="https://github.com/user-attachments/assets/9842313f-b92c-4c35-b7d0-a24aea1c64d1" />

Should be without `lab-files` part. Result:
<img width="572" height="647" alt="image" src="https://github.com/user-attachments/assets/eed1fcad-7a10-46cb-a0da-001c1b8ad175" />
